### PR TITLE
feat: Add CI/CD for Storybook deployment to GitHub Pages

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions: # Added permissions at the workflow level
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
 
@@ -27,5 +32,17 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm run build --if-present
+    - run: npm run build --if-present # This builds the library
     - run: npm test
+
+    - name: Build Storybook
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: npm run storybook:build # Outputs to storybook-static
+
+    - name: Deploy Storybook to GitHub Pages
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./storybook-static
+        # Optional: user_name, user_email, commit_message, publish_branch can be customized if needed

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+storybook-static/

--- a/README.md
+++ b/README.md
@@ -967,6 +967,39 @@ If your TYPO3 API endpoint is correctly configured to render the above Fluid tem
 
 ---
 
+## Live Storybook Demo & Deployment
+
+This project's Storybook is automatically built and deployed to GitHub Pages, providing a live demonstration of the components and Fluid template integration.
+
+### Automated Deployment
+
+*   The Storybook instance is built and deployed via a GitHub Actions workflow defined in `.github/workflows/node.js.yml`.
+*   This deployment occurs automatically whenever changes are pushed to the `main` branch.
+
+### Accessing the Live Demo
+
+*   **View the live Storybook deployment here: [Link to GitHub Pages Site]**
+*   *(Note: Replace `[Link to GitHub Pages Site]` with the actual URL once GitHub Pages is configured and deployed. The URL format is typically `https://<username>.github.io/<repository-name>/` or a custom domain if configured.)*
+
+### First-Time Setup for GitHub Pages (for Repository Maintainers)
+
+If you are the maintainer of this repository or a fork and want to enable GitHub Pages for the first time:
+
+1.  **Wait for Initial Workflow Run:** After your first push to the `main` branch (or after configuring the workflow), the GitHub Actions workflow should attempt a deployment. This will automatically create a `gh-pages` branch (or the branch configured in the workflow) containing your built Storybook static files.
+2.  **Navigate to Repository Settings:** Go to your GitHub repository and click on the "Settings" tab.
+3.  **Go to 'Pages' Section:** In the left sidebar of the settings page, find and click on "Pages" (usually under the "Code and automation" section).
+4.  **Configure Source:**
+    *   Under "Build and deployment", for the "Source" option, select "Deploy from a branch".
+5.  **Select Branch and Folder:**
+    *   From the "Branch" dropdown that appears, choose the `gh-pages` branch (or the branch used by the `peaceiris/actions-gh-pages` action in your workflow, which defaults to `gh-pages`).
+    *   Ensure the folder is set to `/ (root)`.
+    *   Click "Save".
+6.  **Access Your Site:** GitHub will then build your Pages site from the specified branch and provide a URL (e.g., `https://<your-username>.github.io/<your-repository-name>/`). It might take a few minutes for the site to become live after saving. This is the URL you can use for the placeholder link above.
+
+Once set up, subsequent pushes to `main` will automatically update the content on GitHub Pages.
+
+---
+
 ## Contributing
 
 Contributions are welcome! Feel free to open an issue or submit a pull request.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "build-storybook -o ../public/storybook",
+    "storybook:build": "storybook build -o storybook-static",
     "watch": "vite build --watch --mode development",
     "build": "vite build --mode production",
     "build-storybook": "storybook build",


### PR DESCRIPTION
This commit implements automated building and deployment of Storybook to GitHub Pages via a GitHub Actions workflow.

Key changes:

1.  **Storybook Build Configuration (`package.json`):**
    - Modified the `storybook:build` script to output the static build to `./storybook-static/` for consistent deployment.
    - Added `storybook-static/` to `.gitignore`.

2.  **GitHub Workflow (`.github/workflows/node.js.yml`):**
    - Added workflow-level `permissions` for `pages: write` and `id-token: write` to allow deployment.
    - Added new steps to the `build` job that run only on pushes to `main`:
        - "Build Storybook": Executes `npm run storybook:build`.
        - "Deploy Storybook to GitHub Pages": Uses the `peaceiris/actions-gh-pages@v4` action to deploy the contents of `./storybook-static` to the `gh-pages` branch.

3.  **Documentation (`README.md`):**
    - Added a new section "Live Storybook Demo & Deployment".
    - Explains the automated deployment process.
    - Provides clear instructions for the one-time manual setup required in the GitHub repository settings to enable GitHub Pages from the `gh-pages` branch.
    - Includes a placeholder for the live Storybook URL, guiding you on how to find and update it.